### PR TITLE
fix: add autopublish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,25 +12,23 @@ concurrency:
 
 jobs:
   test:
-    name: Test Node.js ${{ matrix.node-version }} on ${{ matrix.os }}
+    name: Test Node.js ${{ matrix.node }} on ${{ matrix.os }}
 
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [14.x, 16.x, 18.x]
+        node: [14, 16, 18]
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
-      - name: Install Node.js
+      - name: Install Node.js ${{ matrix.node }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ matrix.node }}
 
       - name: Enable corepack
         run: corepack enable pnpm && pnpm --version
@@ -40,3 +38,10 @@ jobs:
 
       - name: Run tests
         run: pnpm test
+
+      - name: Maybe Release
+        if: matrix.os == 'ubuntu-latest' && matrix.node == 18 && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
+        run: pnpm dlx semantic-release@19.0.5

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,14 @@
+name: PR
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@00282d63cda40a6eaf3e9d0cbb1ac4384de896e8
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "async-listen",
   "description": "`net.Server#listen()` helper that returns a Promise for async / await",
-  "version": "3.0.0",
+  "version": "0.0.0-development",
   "main": "./dist/index.js",
   "repository": "vercel/async-listen",
   "keywords": [

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  branches: ['main'],
+  tagFormat: '${version}',
+}


### PR DESCRIPTION
This uses semantic release to publish to npm when merging to `main`.

It also adds another workflow to ensure the PR title follows semantic versioning syntax